### PR TITLE
Add more tags to tvinsider.com

### DIFF
--- a/sites/tvinsider.com/tvinsider.com.config.js
+++ b/sites/tvinsider.com/tvinsider.com.config.js
@@ -14,6 +14,7 @@ module.exports = {
     items.forEach(item => {
       const prev = programs[programs.length - 1]
       const $item = cheerio.load(item)
+      const episodeInfo = parseEP($item);
       let start = parseStart($item, date)
       if (!start) return
       if (prev) {
@@ -26,6 +27,9 @@ module.exports = {
         description: parseDescription($item),
         category: parseCategory($item),
         date: parseDate($item),
+        ...episodeInfo, 
+        subTitles: parseSubtitle($item),
+        previouslyShown: parsePreviously($item),
         start,
         stop
       })
@@ -62,6 +66,32 @@ module.exports = {
 
 function parseTitle($item) {
   return $item('h3').text().trim()
+}
+function parseEP($item){
+    const text = $item('h6').text().trim();
+    const match = text.match(/Season\s+(\d+)\s*•\s*Episode\s+(\d+)/i);
+
+    if (!match) return {}; // Return an empty object if no match, so properties are undefined later
+
+    const season = parseInt(match[1], 10);
+    const episode = parseInt(match[2], 10);
+
+    return { season, episode }; // Return an object with season and episode
+}
+
+function parseSubtitle($item) {
+  return $item('h5').text().trim()
+}
+
+function parsePreviously($item){
+  const h3Text = $item('h3').text().trim();
+  const isNewShow = /New$/.test(h3Text);
+
+  if (isNewShow) {
+    return null;
+  } else {
+    return {};
+  }
 }
 
 function parseDescription($item) {


### PR DESCRIPTION
Added episode-num, sub-title and previously-shown (dependent on [this issue](https://github.com/freearhey/epg-grabber/issues/26)) tags to tvinsider's epg data.

The bellow is the xmltv generated with the changes:
```xml
<programme start="20250612063000 +0000" stop="20250612070000 +0000" channel="comedy-central">
    <title lang="en">South Park</title>
    <sub-title lang="en">Pee</sub-title>
    <desc lang="en">Things turn deadly when the boys spend a fun-filled day at the water park.</desc>
    <date>20090101</date>
    <category lang="en">Series</category>
    <episode-num system="xmltv_ns">12.13.0/1</episode-num>
    <episode-num system="onscreen">S13E14</episode-num>
    <previously-shown/>
</programme>
```